### PR TITLE
[Trivial][GUI] Cleanup UI compile warnings

### DIFF
--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -218,7 +218,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalDenomzPiv">
+           <spacer name="horizontalDenomzPiv_1">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/qt/pivx/settings/forms/settingsmultisenddialog.ui
+++ b/src/qt/pivx/settings/forms/settingsmultisenddialog.ui
@@ -103,7 +103,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -222,7 +222,7 @@
           </layout>
          </item>
          <item>
-          <spacer name="horizontalSpacer_3">
+          <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -344,7 +344,7 @@
        </layout>
       </item>
       <item>
-       <spacer name="verticalSpacer_3">
+       <spacer name="verticalSpacer_4">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>

--- a/src/qt/pivx/settings/forms/settingsmultisendwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsmultisendwidget.ui
@@ -31,7 +31,7 @@
    </property>
    <item>
     <widget class="QWidget" name="left" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -45,7 +45,7 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -211,7 +211,7 @@
           <property name="frameShadow">
            <enum>QFrame::Raised</enum>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,8">
+          <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,8">
            <property name="spacing">
             <number>0</number>
            </property>
@@ -254,7 +254,7 @@
              <property name="frameShadow">
               <enum>QFrame::Raised</enum>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout">
+             <layout class="QVBoxLayout" name="verticalLayout_5">
               <property name="spacing">
                <number>30</number>
               </property>
@@ -405,7 +405,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_7">
           <item>
-           <spacer name="horizontalSpacer_5">
+           <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -434,7 +434,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
+           <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -31,7 +31,7 @@
    </property>
    <item>
     <widget class="QWidget" name="left" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_1">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -50,7 +50,7 @@
          <number>0</number>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -81,7 +81,7 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalSpacer_2">
+         <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -97,7 +97,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <layout class="QHBoxLayout" name="horizontalLayout_1">
           <property name="bottomMargin">
            <number>9</number>
           </property>
@@ -109,7 +109,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
+           <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -138,7 +138,7 @@
           <property name="title">
            <string/>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
            <property name="spacing">
             <number>20</number>
            </property>
@@ -165,7 +165,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_6">
+         <spacer name="verticalSpacer_1">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -200,7 +200,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_6">
+         <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -216,12 +216,12 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
           <property name="spacing">
            <number>0</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayoutTitle">
+           <layout class="QVBoxLayout" name="verticalLayoutTitle_1">
             <property name="spacing">
              <number>5</number>
             </property>
@@ -247,7 +247,7 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalSpacer_24">
+         <spacer name="verticalSpacer_3">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -263,7 +263,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="groupBox_1">
           <property name="title">
            <string/>
           </property>
@@ -308,7 +308,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_3">
+         <spacer name="verticalSpacer_4">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -324,12 +324,12 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="2,0,1">
+         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2,0,1">
           <property name="spacing">
            <number>0</number>
           </property>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
             <property name="spacing">
              <number>10</number>
             </property>
@@ -359,7 +359,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
+           <spacer name="horizontalSpacer_1">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -372,7 +372,7 @@
            </spacer>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
             <property name="spacing">
              <number>10</number>
             </property>
@@ -404,7 +404,7 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalSpacer">
+         <spacer name="verticalSpacer_5">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -417,7 +417,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
           <property name="spacing">
            <number>12</number>
           </property>
@@ -454,7 +454,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_5">
+           <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
@@ -31,7 +31,7 @@
    </property>
    <item>
     <widget class="QWidget" name="left" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -73,7 +73,7 @@
          <property name="autoFillBackground">
           <bool>true</bool>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
+         <layout class="QVBoxLayout" name="verticalLayout_1">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -124,7 +124,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_4">
+           <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -145,7 +145,7 @@
              <number>20</number>
             </property>
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_7">
+             <layout class="QVBoxLayout" name="verticalLayout_2">
               <property name="spacing">
                <number>5</number>
               </property>
@@ -186,7 +186,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_1">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -248,7 +248,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -372,7 +372,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -434,7 +434,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_5">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -496,7 +496,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -564,7 +564,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer">
+           <spacer name="verticalSpacer_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>

--- a/src/qt/pivx/settings/forms/settingswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswidget.ui
@@ -37,7 +37,7 @@
        <height>0</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -51,12 +51,12 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout_1">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -105,7 +105,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
            <widget class="QScrollArea" name="scrollArea">
             <property name="styleSheet">
@@ -135,7 +135,7 @@
              <property name="autoFillBackground">
               <bool>true</bool>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_7">
+             <layout class="QVBoxLayout" name="verticalLayout_3">
               <property name="spacing">
                <number>0</number>
               </property>
@@ -155,13 +155,13 @@
                <number>0</number>
               </property>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout">
+               <layout class="QVBoxLayout" name="verticalLayout_4">
                 <item>
                  <widget class="QGroupBox" name="groupBox">
                   <property name="title">
                    <string/>
                   </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_9">
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
                    <property name="spacing">
                     <number>0</number>
                    </property>
@@ -217,7 +217,7 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="fileButtonsWidget" native="true">
-                     <layout class="QVBoxLayout" name="verticalLayout_8">
+                     <layout class="QVBoxLayout" name="verticalLayout_6">
                       <property name="spacing">
                        <number>0</number>
                       </property>
@@ -287,7 +287,7 @@
                     </widget>
                    </item>
                    <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <layout class="QHBoxLayout" name="horizontalLayout_3">
                      <property name="spacing">
                       <number>0</number>
                      </property>
@@ -326,7 +326,7 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="configurationButtonsWidget" native="true">
-                     <layout class="QVBoxLayout" name="verticalLayout_10">
+                     <layout class="QVBoxLayout" name="verticalLayout_7">
                       <property name="spacing">
                        <number>0</number>
                       </property>
@@ -396,7 +396,7 @@
                     </widget>
                    </item>
                    <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <layout class="QHBoxLayout" name="horizontalLayout_4">
                      <property name="spacing">
                       <number>0</number>
                      </property>
@@ -435,7 +435,7 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="optionsButtonsWidget" native="true">
-                     <layout class="QVBoxLayout" name="verticalLayout_11">
+                     <layout class="QVBoxLayout" name="verticalLayout_8">
                       <property name="spacing">
                        <number>0</number>
                       </property>
@@ -799,7 +799,7 @@
    </item>
    <item>
     <widget class="QWidget" name="right" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_5">
+     <layout class="QVBoxLayout" name="verticalLayout_9">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -813,12 +813,12 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <layout class="QVBoxLayout" name="verticalLayout_10">
         <property name="spacing">
          <number>6</number>
         </property>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout">
+         <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
            <widget class="QStackedWidget" name="stackedWidgetContainer"/>
           </item>


### PR DESCRIPTION
Cleaning up compile warnings:

```
  GEN      qt/pivx/settings/forms/ui_settingsdisplayoptionswidget.h
qt/pivx/settings/forms/settingsdisplayoptionswidget.ui: Warning: The name 'horizontalDenomzPiv' (QSpacerItem) is already in use, defaulting to 'horizontalDenomzPiv1'.
  GEN      qt/pivx/settings/forms/ui_settingsmultisenddialog.h
qt/pivx/settings/forms/settingsmultisenddialog.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_31'.
qt/pivx/settings/forms/settingsmultisenddialog.ui: Warning: The name 'horizontalSpacer' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer1'.
  GEN      qt/pivx/settings/forms/ui_settingsmultisendwidget.h
qt/pivx/settings/forms/settingsmultisendwidget.ui: Warning: The name 'verticalLayout' (QVBoxLayout) is already in use, defaulting to 'verticalLayout1'.
qt/pivx/settings/forms/settingsmultisendwidget.ui: Warning: The name 'horizontalSpacer_2' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer_21'.
  GEN      qt/pivx/settings/forms/ui_settingswalletoptionswidget.h
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'verticalSpacer_6' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_61'.
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'horizontalLayout_3' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_31'.
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'verticalLayoutTitle' (QVBoxLayout) is already in use, defaulting to 'verticalLayoutTitle1'.
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'groupBox' (QGroupBox) is already in use, defaulting to 'groupBox1'.
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'verticalLayout_4' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_41'.
qt/pivx/settings/forms/settingswalletoptionswidget.ui: Warning: The name 'horizontalSpacer_2' (QSpacerItem) is already in use, defaulting to'horizontalSpacer_21'.
  GEN      qt/pivx/settings/forms/ui_settingswalletrepairwidget.h
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalLayout_7' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_71'.
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_31'.
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_32'.
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_33'.
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_34'.
qt/pivx/settings/forms/settingswalletrepairwidget.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_35'.
  GEN      qt/pivx/settings/forms/ui_settingswidget.h
qt/pivx/settings/forms/settingswidget.ui: Warning: The name 'horizontalLayout_2' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_21'.
qt/pivx/settings/forms/settingswidget.ui: Warning: The name 'horizontalLayout_2' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_22'.
qt/pivx/settings/forms/settingswidget.ui: Warning: The name 'verticalLayout' (QVBoxLayout) is already in use, defaulting to 'verticalLayout1'.

```