### PR TITLE
[GUI] Correct log errors and build warnings

### DIFF
--- a/src/qt/forms/openuridialog.ui
+++ b/src/qt/forms/openuridialog.ui
@@ -37,7 +37,7 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
        <number>5</number>
       </property>

--- a/src/qt/forms/zpivcontroldialog.ui
+++ b/src/qt/forms/zpivcontroldialog.ui
@@ -19,7 +19,7 @@
         <property name="windowTitle">
             <string>Select zPIV to Spend</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+        <layout class="QVBoxLayout" name="verticalLayout_1" stretch="0">
             <property name="spacing">
                 <number>0</number>
             </property>
@@ -68,7 +68,7 @@
                                     <number>30</number>
                                 </property>
                                 <item>
-                                    <spacer name="horizontalSpacer_4">
+                                    <spacer name="horizontalSpacer_1">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>
@@ -109,7 +109,7 @@
                                     </widget>
                                 </item>
                                 <item>
-                                    <spacer name="horizontalSpacer_5">
+                                    <spacer name="horizontalSpacer_2">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>
@@ -177,7 +177,7 @@
                                     </widget>
                                 </item>
                                 <item>
-                                    <spacer name="horizontalSpacer_2">
+                                    <spacer name="horizontalSpacer_3">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>
@@ -213,7 +213,7 @@
                                     </widget>
                                 </item>
                                 <item>
-                                    <spacer name="horizontalSpacer_2">
+                                    <spacer name="horizontalSpacer_4">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>
@@ -258,7 +258,7 @@
                                     </widget>
                                 </item>
                                 <item>
-                                    <spacer name="horizontalSpacer">
+                                    <spacer name="horizontalSpacer_5">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>
@@ -273,7 +273,7 @@
                             </layout>
                         </item>
                         <item>
-                            <layout class="QVBoxLayout" name="verticalLayout">
+                            <layout class="QVBoxLayout" name="verticalLayout_3">
                                 <property name="leftMargin">
                                     <number>20</number>
                                 </property>
@@ -352,7 +352,7 @@
                                     <number>26</number>
                                 </property>
                                 <item>
-                                    <spacer name="horizontalSpacer_3">
+                                    <spacer name="horizontalSpacer_6">
                                         <property name="orientation">
                                             <enum>Qt::Horizontal</enum>
                                         </property>

--- a/src/qt/pivx/forms/coincontrolpivwidget.ui
+++ b/src/qt/pivx/forms/coincontrolpivwidget.ui
@@ -54,7 +54,7 @@
        <number>20</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_31">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -150,10 +150,10 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QWidget" name="layoutAmount" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2_1" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleAmount">
              <property name="text">
@@ -189,7 +189,7 @@
         </item>
         <item>
          <widget class="QWidget" name="layoutQuantity" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_51" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2_2" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleQuantity">
              <property name="text">
@@ -225,7 +225,7 @@
         </item>
         <item>
          <widget class="QWidget" name="layoutFee" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2_3" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleFee">
              <property name="text">
@@ -262,7 +262,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QLabel" name="labelTitleDenom">
           <property name="text">
@@ -351,7 +351,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
          <widget class="QCheckBox" name="checkBoxAll">
           <property name="text">
@@ -362,13 +362,13 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_31">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <property name="spacing">
          <number>20</number>
         </property>
         <item>
          <widget class="QWidget" name="layoutBytes" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_41" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_5_1" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleBytes">
              <property name="text">
@@ -388,7 +388,7 @@
         </item>
         <item>
          <widget class="QWidget" name="layoutDust" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_52" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_5_2" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleDust">
              <property name="text">
@@ -408,7 +408,7 @@
         </item>
         <item>
          <widget class="QWidget" name="layoutChange" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_53" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_5_3" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleChange">
              <property name="text">
@@ -428,7 +428,7 @@
         </item>
         <item>
          <widget class="QWidget" name="layoutAfter" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_54" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalLayout_5_4" stretch="0,1">
            <item>
             <widget class="QLabel" name="labelTitleAfter">
              <property name="text">
@@ -465,7 +465,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <property name="leftMargin">
          <number>0</number>
         </property>

--- a/src/qt/pivx/forms/masternodewizarddialog.ui
+++ b/src/qt/pivx/forms/masternodewizarddialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -37,7 +37,7 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
        <number>0</number>
       </property>
@@ -48,7 +48,7 @@
        <number>20</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -56,7 +56,7 @@
          <number>20</number>
         </property>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -97,7 +97,7 @@
           <height>24</height>
          </size>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -114,7 +114,7 @@
           <number>0</number>
          </property>
          <item>
-          <spacer name="horizontalSpacer_7">
+          <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -411,7 +411,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_8">
+          <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -475,7 +475,7 @@
              <number>0</number>
             </property>
             <item>
-             <spacer name="horizontalSpacer_9">
+             <spacer name="horizontalSpacer_4">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -519,7 +519,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_3">
+             <spacer name="horizontalSpacer_5">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -557,7 +557,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_2">
+             <spacer name="horizontalSpacer_6">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -595,7 +595,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_6">
+             <spacer name="horizontalSpacer_7">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -617,7 +617,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer">
+       <spacer name="verticalSpacer_1">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -647,7 +647,7 @@
          </size>
         </property>
         <widget class="QWidget" name="page_1">
-         <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0,3,0,0,0">
+         <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,3,0,0,0">
           <property name="spacing">
            <number>6</number>
           </property>
@@ -683,7 +683,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_2">
+           <spacer name="verticalSpacer_1_1">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -712,7 +712,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_8">
+           <spacer name="verticalSpacer_1_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -744,7 +744,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_7">
+           <spacer name="verticalSpacer_1_3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -759,7 +759,7 @@
          </layout>
         </widget>
         <widget class="QWidget" name="page_3">
-         <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,0,3">
+         <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,3">
           <property name="spacing">
            <number>6</number>
           </property>
@@ -795,7 +795,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_2">
+           <spacer name="verticalSpacer_1_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -811,7 +811,7 @@
            <widget class="QLineEdit" name="lineEditName"/>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_1_5">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -842,7 +842,7 @@
          </layout>
         </widget>
         <widget class="QWidget" name="page_4">
-         <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,0,0,0,0,0,0,0,0">
+         <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,0,0,0,0,0,0,0,0,0,0">
           <property name="spacing">
            <number>6</number>
           </property>
@@ -891,7 +891,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_2">
+           <spacer name="verticalSpacer_1_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -917,7 +917,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_4">
+           <spacer name="verticalSpacer_1_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -936,7 +936,7 @@
            <widget class="QLineEdit" name="lineEditIpAddress"/>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_1_8">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -962,7 +962,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_5">
+           <spacer name="verticalSpacer_1_9">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -981,7 +981,7 @@
            <widget class="QLineEdit" name="lineEditPort"/>
           </item>
           <item>
-           <spacer name="verticalSpacer_6">
+           <spacer name="verticalSpacer_1_10">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -998,7 +998,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_9">
+       <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -1011,9 +1011,9 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2,2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,2,2">
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_8">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/src/qt/pivx/forms/privacywidget.ui
+++ b/src/qt/pivx/forms/privacywidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
+  <layout class="QHBoxLayout" name="horizontalLayout_1" stretch="2,1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -61,7 +61,7 @@
            <number>20</number>
           </property>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
             <property name="spacing">
              <number>0</number>
             </property>
@@ -115,7 +115,7 @@
                 <property name="title">
                  <string/>
                 </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <layout class="QHBoxLayout" name="horizontalLayout_2_1">
                  <property name="spacing">
                   <number>0</number>
                  </property>
@@ -218,7 +218,7 @@
            </spacer>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2">
             <property name="spacing">
              <number>0</number>
             </property>
@@ -247,7 +247,7 @@
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,0">
+               <layout class="QHBoxLayout" name="horizontalLayout_3_1" stretch="1,0,0">
                 <property name="spacing">
                  <number>0</number>
                 </property>
@@ -315,7 +315,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -575,7 +575,7 @@
             <number>0</number>
            </property>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_84">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_1">
              <item>
               <widget class="QLabel" name="labelTitleDenom1">
                <property name="text">
@@ -596,7 +596,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_2">
              <item>
               <widget class="QLabel" name="labelTitleDenom5">
                <property name="text">
@@ -617,7 +617,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_81">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_3">
              <item>
               <widget class="QLabel" name="labelTitleDenom10">
                <property name="text">
@@ -638,7 +638,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_82">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_4">
              <item>
               <widget class="QLabel" name="labelTitleDenom50">
                <property name="text">
@@ -659,7 +659,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_5">
              <item>
               <widget class="QLabel" name="labelTitleDenom100">
                <property name="text">
@@ -680,7 +680,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_6">
              <item>
               <widget class="QLabel" name="labelTitleDenom500">
                <property name="text">
@@ -701,7 +701,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_83">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_7">
              <item>
               <widget class="QLabel" name="labelTitleDenom1000">
                <property name="text">
@@ -722,7 +722,7 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <layout class="QHBoxLayout" name="horizontalLayout_4_8">
              <item>
               <widget class="QLabel" name="labelTitleDenom5000">
                <property name="text">

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -71,7 +71,7 @@
          <number>20</number>
         </property>
         <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -112,7 +112,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -868,7 +868,7 @@ background:transparent;
           <number>20</number>
          </property>
          <item>
-          <spacer name="horizontalSpacer">
+          <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>

--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -31,7 +31,7 @@
    </property>
    <item>
     <widget class="QWidget" name="frame_2" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_1">
       <property name="spacing">
        <number>0</number>
       </property>
@@ -61,7 +61,7 @@
           <height>520</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_9">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -73,7 +73,7 @@
          </property>
          <item>
           <widget class="QWidget" name="frame" native="true">
-           <layout class="QVBoxLayout" name="verticalLayout_6">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <property name="spacing">
              <number>0</number>
             </property>
@@ -750,7 +750,7 @@
             <item>
              <widget class="QStackedWidget" name="stackedWidget">
               <widget class="QWidget" name="page_0">
-               <layout class="QVBoxLayout" name="verticalLayout_2">
+               <layout class="QVBoxLayout" name="verticalLayout_4">
                 <property name="leftMargin">
                  <number>40</number>
                 </property>
@@ -758,7 +758,7 @@
                  <number>40</number>
                 </property>
                 <item>
-                 <spacer name="verticalSpacer_4">
+                 <spacer name="verticalSpacer_1">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -776,7 +776,7 @@
                </layout>
               </widget>
               <widget class="QWidget" name="page_1">
-               <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0,0,0,0">
+               <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,0,0,0,0">
                 <property name="spacing">
                  <number>6</number>
                 </property>
@@ -793,7 +793,7 @@
                  <number>12</number>
                 </property>
                 <item>
-                 <spacer name="verticalSpacer_3">
+                 <spacer name="verticalSpacer_2">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -828,7 +828,7 @@
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_2">
+                 <spacer name="verticalSpacer_3">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -844,7 +844,7 @@
                  <widget class="QComboBox" name="comboBoxLanguage"/>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_7">
+                 <spacer name="verticalSpacer_4">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -859,7 +859,7 @@
                </layout>
               </widget>
               <widget class="QWidget" name="page_2">
-               <layout class="QVBoxLayout" name="verticalLayout_2">
+               <layout class="QVBoxLayout" name="verticalLayout_6">
                 <property name="leftMargin">
                  <number>40</number>
                 </property>
@@ -867,7 +867,7 @@
                  <number>40</number>
                 </property>
                 <item>
-                 <spacer name="verticalSpacer_4">
+                 <spacer name="verticalSpacer_5">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -884,7 +884,7 @@
                 </item>
                 <item>
                  <widget class="QWidget" name="widget_3" native="true">
-                  <layout class="QVBoxLayout" name="verticalLayout_5" stretch="1,0,1,0">
+                  <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,0,1,0">
                    <property name="spacing">
                     <number>0</number>
                    </property>
@@ -921,7 +921,7 @@ PIVX Core Wallet</string>
                     </widget>
                    </item>
                    <item>
-                    <spacer name="verticalSpacer_9">
+                    <spacer name="verticalSpacer_5_1">
                      <property name="orientation">
                       <enum>Qt::Vertical</enum>
                      </property>
@@ -950,7 +950,7 @@ PIVX Core Wallet</string>
                     </widget>
                    </item>
                    <item>
-                    <spacer name="verticalSpacer_8">
+                    <spacer name="verticalSpacer_5_2">
                      <property name="orientation">
                       <enum>Qt::Vertical</enum>
                      </property>
@@ -968,7 +968,7 @@ PIVX Core Wallet</string>
                </layout>
               </widget>
               <widget class="QWidget" name="page_3">
-               <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,3">
+               <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,3">
                 <property name="spacing">
                  <number>6</number>
                 </property>
@@ -985,7 +985,7 @@ PIVX Core Wallet</string>
                  <number>12</number>
                 </property>
                 <item>
-                 <spacer name="verticalSpacer_5">
+                 <spacer name="verticalSpacer_6">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -1017,7 +1017,7 @@ PIVX Core Wallet</string>
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_2">
+                 <spacer name="verticalSpacer_7">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -1045,7 +1045,7 @@ PIVX Core Wallet</string>
                </layout>
               </widget>
               <widget class="QWidget" name="page_4">
-               <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,0,0">
+               <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0,0,0,0,0">
                 <property name="spacing">
                  <number>6</number>
                 </property>
@@ -1062,7 +1062,7 @@ PIVX Core Wallet</string>
                  <number>12</number>
                 </property>
                 <item>
-                 <spacer name="verticalSpacer_10">
+                 <spacer name="verticalSpacer_8">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -1097,7 +1097,7 @@ PIVX Core Wallet</string>
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_2">
+                 <spacer name="verticalSpacer_9">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>
@@ -1126,7 +1126,7 @@ PIVX Core Wallet</string>
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_6">
+                 <spacer name="verticalSpacer_10">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>


### PR DESCRIPTION
Another round of correcting UI warnings; I thought i had them all but then I did a clean rebuild and found more.

```
qt/forms/openuridialog.ui: Warning: The name 'verticalLayout' (QVBoxLayout) is already in use, defaulting to 'verticalLayout1'.
qt/forms/zpivcontroldialog.ui: Warning: The name 'horizontalSpacer_2' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer_21'.
qt/forms/zpivcontroldialog.ui: Warning: The name 'verticalLayout' (QVBoxLayout) is already in use, defaulting to 'verticalLayout1'.
qt/pivx/forms/coincontrolpivwidget.ui: Warning: The name 'horizontalLayout_31' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_311'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_21'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'verticalLayout_10' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_101'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_22'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'verticalSpacer_3' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_31'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'horizontalLayout' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout1'.
qt/pivx/forms/masternodewizarddialog.ui: Warning: The name 'horizontalSpacer' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer1'.
qt/pivx/forms/sendconfirmdialog.ui: Warning: The name 'horizontalSpacer' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer1'.
qt/pivx/forms/privacywidget.ui: Warning: The name 'horizontalLayout_8' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_83'.
qt/pivx/forms/privacywidget.ui: Warning: The name 'horizontalLayout_8' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_85'.
qt/pivx/forms/privacywidget.ui: Warning: The name 'horizontalLayout_83' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_831'.
qt/pivx/forms/privacywidget.ui: Warning: The name 'horizontalLayout_8' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_86'.
qt/pivx/forms/welcomecontentwidget.ui: Warning: The name 'verticalLayout_2' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_21'.
qt/pivx/forms/welcomecontentwidget.ui: Warning: The name 'verticalSpacer_4' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_41'.
qt/pivx/forms/welcomecontentwidget.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_21'.
qt/pivx/forms/welcomecontentwidget.ui: Warning: The name 'verticalLayout_10' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_101'.
qt/pivx/forms/welcomecontentwidget.ui: Warning: The name 'verticalSpacer_2' (QSpacerItem) is already in use, defaulting to 'verticalSpacer_22'.
```

Also, I noticed a number of `No Matching Signal` errors in the logfile.  This is due to the Qt MetaObject `connectSlotsByName` searching for `connect()` code with slot objects that conform to the format `on_<object-name>_<signal-name>`.  A number of signals in the new GUI conformed to that format; so connectSlotsByName picked them up when they shouldn't have been.

```
GUI: QMetaObject::connectSlotsByName: No matching signal for on_encryptKeyButton_ENC_clicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_clear_all()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_signMessageButton_SM_clicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_pasteButton_SM_clicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_addressBookButton_SM_clicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_clear_all()
```

A couple other issues I went after but I couldn't quite solve yet is:

```

2019-08-25 02:39:13 GUI: QGradient::setColorAt: Color position must be specified in the range 0 to 1
2019-08-25 02:39:13 GUI: QGradient::setColorAt: Color position must be specified in the range 0 to 1
2019-08-25 02:39:13 GUI: QObject::connect: No such slot SettingsWidget::updateHideOrphans(bool) in qt/pivx/settings/settingswidget.cpp:178
2019-08-25 02:39:13 GUI: QObject::connect:  (receiver name: 'SettingsWidget')
2019-08-25 02:39:13 GUI: QLayout: Attempting to add QLayout "" to DashboardWidget "DashboardWidget", which already has a layout
2019-08-25 02:39:14 GUI: QObject::connect: No such slot PIVXGUI::handlePaymentRequest(SendCoinsRecipient) in qt/pivx.cpp:487
```

I didn't want to hold this up any longer while I dug around for what was causing those.