### PR TITLE
1963 additions - mapSaplingNoteData

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -16,6 +16,7 @@ class OutPointWrapper {
 public:
     BaseOutPoint outPoint;
     CAmount value;
+    bool isP2CS;
 
     bool operator<(const OutPointWrapper& obj2) const {
         return this->outPoint < obj2.outPoint;
@@ -69,17 +70,17 @@ public:
 
     bool IsSelected(const BaseOutPoint& output) const
     {
-        return (setSelected.count(OutPointWrapper{output, 0}) > 0);
+        return (setSelected.count(OutPointWrapper{output, 0, false}) > 0);
     }
 
-    void Select(const BaseOutPoint& output, CAmount value = 0)
+    void Select(const BaseOutPoint& output, CAmount value = 0, bool isP2CS = false)
     {
-        setSelected.insert(OutPointWrapper{output, value});
+        setSelected.insert(OutPointWrapper{output, value, isP2CS});
     }
 
     void UnSelect(const BaseOutPoint& output)
     {
-        setSelected.erase(OutPointWrapper{output, 0});
+        setSelected.erase(OutPointWrapper{output, 0, false});
     }
 
     void UnSelectAll()

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -459,7 +459,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         else {
             CAmount value = 0;
             ParseFixedPoint(item->text(COLUMN_AMOUNT).toStdString(), 8, &value);
-            coinControl->Select(outpt, value);
+            bool isP2CS = item->data(COLUMN_CHECKBOX, Qt::UserRole) == QString("Delegated");
+            coinControl->Select(outpt, value, isP2CS);
         }
 
         // selection changed -> update labels
@@ -493,13 +494,13 @@ void CoinControlDialog::updateLabels()
             "Select PIV Outputs to Spend" :
             "Select Shielded PIV to Spend");
 
-    // nPayAmount
+    // nPayAmount (!todo fix dust)
     CAmount nPayAmount = 0;
     bool fDust = false;
-    for (const CAmount& amount : payAmounts) {
-        nPayAmount += amount;
-        if (amount > 0) {
-            CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
+    for (const auto& amount : payAmounts) {
+        nPayAmount += amount.first;
+        if (amount.first > 0) {
+            CTxOut txout(amount.first, (CScript)std::vector<unsigned char>(24, 0));
             if (IsDust(txout, ::minRelayTxFee))
                 fDust = true;
         }
@@ -514,40 +515,16 @@ void CoinControlDialog::updateLabels()
     unsigned int nQuantity = 0;
 
     std::vector<OutPointWrapper> vCoinControl;
-    std::vector<COutput> vOutputs;
     coinControl->ListSelected(vCoinControl);
-    model->getOutputs(vCoinControl, vOutputs);
 
-    if (fSelectTransparent) {
-        for (const COutput& out : vOutputs) {
-            // unselect already spent, very unlikely scenario, this could happen
-            // when selected are spent elsewhere, like rpc or another computer
-            uint256 txhash = out.tx->GetHash();
-            COutPoint outpt(txhash, out.i);
-            if (model->isSpent(outpt)) {
-                coinControl->UnSelect(outpt);
-                continue;
-            }
-
-            // Quantity
-            nQuantity++;
-            // Amount
-            nAmount += out.tx->vout[out.i].nValue;
-            // Bytes
-            nBytesInputs += CTXIN_SPEND_DUST_SIZE;
-            // Additional byte for P2CS
-            if (out.tx->vout[out.i].scriptPubKey.IsPayToColdStaking())
-                nBytesInputs++;
-        }
-    } else {
-        for (const OutPointWrapper& out : vCoinControl) {
-            // Quantity
-            nQuantity++;
-            // Amount
-            nAmount += out.value;
-            // Bytes
-            nBytesInputs += SPENDDESCRIPTION_SIZE;
-        }
+    for (const OutPointWrapper& out : vCoinControl) {
+        // Quantity
+        nQuantity++;
+        // Amount
+        nAmount += out.value;
+        // Bytes
+        nBytesInputs += (fSelectTransparent ? (CTXIN_SPEND_DUST_SIZE + (out.isP2CS ? 1 : 0))
+                                            : SPENDDESCRIPTION_SIZE);
     }
 
     // update SelectAll button state
@@ -558,15 +535,20 @@ void CoinControlDialog::updateLabels()
     // calculation
     const int P2CS_OUT_SIZE = 61;
     if (nQuantity > 0) {
-        // Bytes: nBytesInputs + (num_of_outputs * bytes_per_output)
+        bool isShieldedTx = !fSelectTransparent;
+        // Bytes: nBytesInputs + (sum of nBytesOutputs)
         // always assume +1 (p2pkh) output for change here
-        if (fSelectTransparent) {
-            nBytes = nBytesInputs + std::max(1, payAmounts.size()) * (
-                    forDelegation ? P2CS_OUT_SIZE : CTXOUT_REGULAR_SIZE);
-            nBytes += CTXOUT_REGULAR_SIZE;
-        } else {
-            nBytes = nBytesInputs + std::max(1, payAmounts.size()) * SPENDDESCRIPTION_SIZE;
-            nBytes += SPENDDESCRIPTION_SIZE;
+        nBytes = nBytesInputs + (fSelectTransparent ? CTXOUT_REGULAR_SIZE : OUTPUTDESCRIPTION_SIZE);
+        for (const auto& a : payAmounts) {
+            bool shieldedOut = a.second;
+            isShieldedTx |= shieldedOut;
+            nBytes += (shieldedOut ? OUTPUTDESCRIPTION_SIZE
+                                   : (forDelegation ? P2CS_OUT_SIZE : CTXOUT_REGULAR_SIZE));
+        }
+
+        // Shielded txes must include a binding sig
+        if (isShieldedTx) {
+            nBytes + BINDINGSIG_SIZE;
         }
 
         // nVersion, nLockTime and vin/vout len sizes
@@ -836,9 +818,9 @@ void CoinControlDialog::clearPayAmounts()
     payAmounts.clear();
 }
 
-void CoinControlDialog::addPayAmount(const CAmount& amount)
+void CoinControlDialog::addPayAmount(const CAmount& amount, bool isShieldedRecipient)
 {
-    payAmounts.push_back(amount);
+    payAmounts.emplace_back(amount, isShieldedRecipient);
 }
 
 void CoinControlDialog::updatePushButtonSelectAll(bool checked)

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -52,7 +52,7 @@ public:
     void updateView();
     void refreshDialog();
     void clearPayAmounts();
-    void addPayAmount(const CAmount& amount);
+    void addPayAmount(const CAmount& amount, bool isShieldedRecipient);
     void setSelectionType(bool isTransparent) { fSelectTransparent = isTransparent; }
 
     CCoinControl* coinControl;
@@ -64,7 +64,8 @@ private:
     int sortColumn;
     Qt::SortOrder sortOrder;
     bool forDelegation;
-    QList<CAmount> payAmounts{};
+    // pair (recipient amount, ishielded recipient)
+    std::vector<std::pair<CAmount, bool>> payAmounts{};
     unsigned int nSelectableInputs{0};
 
     // whether should show available utxo or notes.

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -547,7 +547,7 @@ void ColdStakingWidget::setCoinControlPayAmounts()
 {
     if (!coinControlDialog) return;
     coinControlDialog->clearPayAmounts();
-    coinControlDialog->addPayAmount(sendMultiRow->getAmountValue());
+    coinControlDialog->addPayAmount(sendMultiRow->getAmountValue(), false);
 }
 
 void ColdStakingWidget::onColdStakeClicked()

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -692,7 +692,7 @@ void SendWidget::setCoinControlPayAmounts()
     coinControlDialog->clearPayAmounts();
     QMutableListIterator<SendMultiRow*> it(entries);
     while (it.hasNext()) {
-        coinControlDialog->addPayAmount(it.next()->getAmountValue());
+        coinControlDialog->addPayAmount(it.next()->getAmountValue(), !isTransparent);
     }
 }
 

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -306,9 +306,9 @@ void TxDetailDialog::onOutputsClicked()
                         // Obtain the noteData to get the cached amount value
                         SaplingNoteData noteData = walletTx->mapSaplingNoteData.at(op);
                         Optional<libzcash::SaplingPaymentAddress> opAddr =
-                                pwalletMain->GetSaplingScriptPubKeyMan()->GetShieldedAddressFrom(*walletTx, op);
+                                pwalletMain->GetSaplingScriptPubKeyMan()->GetOutPointAddress(*walletTx, op);
 
-                        QString labelRes = QString::fromStdString(Standard::EncodeDestination(*opAddr));
+                        QString labelRes = opAddr ? QString::fromStdString(Standard::EncodeDestination(*opAddr)) : "";
                         labelRes = labelRes.left(18) + "..." + labelRes.right(18);
                         appendOutput(layoutGrid, i, labelRes, *noteData.amount, nDisplayUnit);
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -211,7 +211,7 @@ bool TransactionRecord::decomposeCreditTransaction(const CWallet* wallet, const 
         auto sspkm = wallet->GetSaplingScriptPubKeyMan();
         for (int i = 0; i < (int) wtx.sapData->vShieldedOutput.size(); ++i) {
             SaplingOutPoint out(sub.hash, i);
-            auto opAddr = sspkm->GetShieldedAddressFrom(wtx, out);
+            auto opAddr = sspkm->GetOutPointAddress(wtx, out);
             if (opAddr) {
                 // skip it if change
                 if (sspkm->IsNoteSaplingChange(out, *opAddr)) {
@@ -294,7 +294,7 @@ bool TransactionRecord::decomposeShieldedDebitTransaction(const CWallet* wallet,
     bool feeAdded = false;
     for (int i = 0; i < (int) wtx.sapData->vShieldedOutput.size(); ++i) {
         SaplingOutPoint out(sub.hash, i);
-        auto opAddr = sspkm->GetShieldedAddressFrom(wtx, out);
+        auto opAddr = sspkm->GetOutPointAddress(wtx, out);
         // skip change
         if (!opAddr || sspkm->IsNoteSaplingChange(out, *opAddr)) {
             continue;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -145,7 +145,7 @@ public:
                                                       const CAmount& nDebit, bool involvesWatchAddress,
                                                       QList<TransactionRecord>& parts);
 
-    static bool decomposeShieldedDebitTransaction(const CWallet* wallet, const CWalletTx& wtx,
+    static bool decomposeShieldedDebitTransaction(const CWallet* wallet, const CWalletTx& wtx, CAmount nTxFee,
                                                   bool involvesWatchAddress, QList<TransactionRecord>& parts);
 
     static std::string getValueOrReturnEmpty(const std::map<std::string, std::string>& mapValue, const std::string& key);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -71,6 +71,11 @@ bool WalletModel::isColdStakingNetworkelyEnabled() const
     return !sporkManager.IsSporkActive(SPORK_19_COLDSTAKING_MAINTENANCE);
 }
 
+bool WalletModel::isSaplingInMaintenance() const
+{
+    return sporkManager.IsSporkActive(SPORK_20_SAPLING_MAINTENANCE);
+}
+
 bool WalletModel::isStakingStatusActive() const
 {
     return wallet && wallet->pStakerStatus && wallet->pStakerStatus->IsActive();
@@ -457,15 +462,15 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     bool fColdStakingActive = isColdStakingNetworkelyEnabled();
     bool fSaplingActive = Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V5_DUMMY);
 
-    // Double check tx before do anything
+    // Double check the tx before doing anything
+    CWalletTx* newTx = transaction.getTransaction();
     CValidationState state;
-    if (!CheckTransaction(*transaction.getTransaction(), true, true, state, true, fColdStakingActive, fSaplingActive)) {
+    if (!CheckTransaction(*newTx, true, true, state, true, fColdStakingActive, fSaplingActive)) {
         return TransactionCheckFailed;
     }
 
     {
         LOCK2(cs_main, wallet->cs_wallet);
-        CWalletTx* newTx = transaction.getTransaction();
         QList<SendCoinsRecipient> recipients = transaction.getRecipients();
 
         // Store PaymentRequests in wtx.vOrderForm in wallet.

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -909,20 +909,6 @@ std::string WalletModel::getLabelForAddress(const CTxDestination& address)
     return label;
 }
 
-// returns a list of COutputs from COutPoints
-void WalletModel::getOutputs(const std::vector<OutPointWrapper>& vOutpoints, std::vector<COutput>& vOutputs)
-{
-    LOCK2(cs_main, wallet->cs_wallet);
-    for (const auto& outpoint : vOutpoints) {
-        const auto* tx = wallet->GetWalletTx(outpoint.outPoint.hash);
-        if (!tx) continue;
-        bool fConflicted;
-        const int nDepth = tx->GetDepthAndMempool(fConflicted);
-        if (nDepth < 0 || fConflicted) continue;
-        vOutputs.emplace_back(tx, outpoint.outPoint.n, nDepth, true, true);
-    }
-}
-
 // returns a COutPoint of 10000 PIV if found
 bool WalletModel::getMNCollateralCandidate(COutPoint& outPoint)
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -150,6 +150,7 @@ public:
     bool isRegTestNetwork() const;
     /** Whether cold staking is enabled or disabled in the network **/
     bool isColdStakingNetworkelyEnabled() const;
+    bool isSaplingInMaintenance() const;
     CAmount getMinColdStakingAmount() const;
     /* current staking status from the miner thread **/
     bool isStakingStatusActive() const;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -282,7 +282,6 @@ public:
     bool isMine(const QString& addressStr);
     bool IsShieldedDestination(const CWDestination& address);
     bool isUsed(CTxDestination address);
-    void getOutputs(const std::vector<OutPointWrapper>& vOutpoints, std::vector<COutput>& vOutputs);
     bool getMNCollateralCandidate(COutPoint& outPoint);
     bool isSpent(const COutPoint& outpoint) const;
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -123,11 +123,10 @@ OperationResult SaplingOperation::build()
                 return result;
             }
         } else {
-            // Sending from a t-address, which we don't have an ovk for. Instead,
-            // generate a common one from the HD seed. This ensures the data is
-            // recoverable, while keeping it logically separate from the ZIP 32
-            // Sapling key hierarchy, which the user might not be using.
-            ovk = pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVKFromSeed();
+            // Get the common OVK for recovering t->shield outputs.
+            // If not already databased, a new one will be generated from the HD seed.
+            // It is safe to do it here, as the wallet is unlocked.
+            ovk = pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVK();
         }
 
         // Add outputs

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -592,19 +592,19 @@ Optional<std::pair<
                   "Unlock the wallet and call 'viewshieldedtransaction %s' to fix.\n", tx.GetHash().ToString());
     }
     if (!tx.sapData->vShieldedSpend.empty()) {
-        const auto& it = mapSaplingNullifiersToNotes.find(tx.sapData->vShieldedSpend[0].nullifier);
+        const auto& spend = tx.sapData->vShieldedSpend[0];
+        const auto& it = mapSaplingNullifiersToNotes.find(spend.nullifier);
         if (it != mapSaplingNullifiersToNotes.end()) {
             const SaplingOutPoint& prevOut = it->second;
             const CWalletTx* txPrev = wallet->GetWalletTx(prevOut.hash);
             if (!txPrev) return nullopt;
+
             const auto& itPrev = txPrev->mapSaplingNoteData.find(prevOut);
             if (itPrev != txPrev->mapSaplingNoteData.end()) {
                 const SaplingNoteData& noteData = itPrev->second;
-                libzcash::SaplingExtendedSpendingKey extsk;
                 libzcash::SaplingExtendedFullViewingKey extfvk;
-                if (wallet->GetSaplingFullViewingKey(noteData.ivk, extfvk) &&
-                    wallet->GetSaplingSpendingKey(extfvk, extsk)) {
-                    ovks.emplace(extsk.expsk.ovk);
+                if (wallet->GetSaplingFullViewingKey(noteData.ivk, extfvk)) {
+                    ovks.emplace(extfvk.fvk.ovk);
                 }
             }
         }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -1196,8 +1196,7 @@ uint256 SaplingScriptPubKeyMan::getCommonOVK()
     return *commonOVK;
 }
 
-
-uint256 SaplingScriptPubKeyMan::getCommonOVKFromSeed()
+uint256 SaplingScriptPubKeyMan::getCommonOVKFromSeed() const
 {
     // Sending from a t-address, which we don't have an ovk for. Instead,
     // generate a common one from the HD seed. This ensures the data is

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -578,7 +578,6 @@ Optional<std::pair<
         SaplingScriptPubKeyMan::TryToRecoverNote(const CWalletTx& tx, const SaplingOutPoint& op)
 {
     // Try to recover it with the ovks.
-    // todo: should add all of the wallet's ovk as well.
     std::set<uint256> ovks;
     // Get the common OVK for recovering t->shield outputs.
     // If not already databased, a new one will be generated from the HD seed (this throws an error if the
@@ -591,14 +590,12 @@ Optional<std::pair<
         LogPrintf("WARNING: No CommonOVK found. Some notes might not be correctly recovered. "
                   "Unlock the wallet and call 'viewshieldedtransaction %s' to fix.\n", tx.GetHash().ToString());
     }
-    if (!tx.sapData->vShieldedSpend.empty()) {
-        const auto& spend = tx.sapData->vShieldedSpend[0];
+    for (const auto& spend : tx.sapData->vShieldedSpend) {
         const auto& it = mapSaplingNullifiersToNotes.find(spend.nullifier);
         if (it != mapSaplingNullifiersToNotes.end()) {
             const SaplingOutPoint& prevOut = it->second;
             const CWalletTx* txPrev = wallet->GetWalletTx(prevOut.hash);
-            if (!txPrev) return nullopt;
-
+            if (!txPrev) continue;
             const auto& itPrev = txPrev->mapSaplingNoteData.find(prevOut);
             if (itPrev != txPrev->mapSaplingNoteData.end()) {
                 const SaplingNoteData& noteData = itPrev->second;

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -344,6 +344,7 @@ std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> SaplingScriptPubKe
             nd.ivk = ivk;
             nd.amount = result->value();
             nd.address = address;
+            nd.memo = result->memo();
             noteData.insert(std::make_pair(op, nd));
             break;
         }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -1156,6 +1156,12 @@ void SaplingScriptPubKeyMan::SetHDSeed(const CKeyID& keyID, bool force, bool mem
     }
 
     SetHDChain(newHdChain, memonly);
+
+    // Update the commonOVK to recover t->shield notes
+    commonOVK = getCommonOVKFromSeed();
+    if (!memonly && !CWalletDB(wallet->strWalletFile).WriteSaplingCommonOVK(*commonOVK)) {
+        throw std::runtime_error(std::string(__func__) + ": writing sapling commonOVK failed");
+    }
 }
 
 void SaplingScriptPubKeyMan::SetHDChain(CHDChain& chain, bool memonly)

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -644,6 +644,9 @@ CAmount SaplingScriptPubKeyMan::GetCredit(const CWalletTx& tx, const isminefilte
         // Obtain the noteData and check if the nullifier has being spent or not
         SaplingNoteData noteData = tx.mapSaplingNoteData.at(op);
 
+        // Skip externally sent notes
+        if (!noteData.IsMyNote()) continue;
+
         // The nullifier could be null if the wallet was locked when the noteData was created.
         if (noteData.nullifier &&
             (fUnspent && IsSaplingSpent(*noteData.nullifier))) {

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -344,7 +344,11 @@ std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> SaplingScriptPubKe
             nd.ivk = ivk;
             nd.amount = result->value();
             nd.address = address;
-            nd.memo = result->memo();
+            const auto& memo = result->memo();
+            // don't save empty memo (starting with 0xF6)
+            if (memo[0] < 0xF6) {
+                nd.memo = memo;
+            }
             noteData.insert(std::make_pair(op, nd));
             break;
         }

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -106,10 +106,18 @@ public:
         READWRITE(nullifier);
         READWRITE(witnesses);
         READWRITE(witnessHeight);
+        READWRITE(amount);
+        READWRITE(address);
+        READWRITE(memo);
     }
 
     friend bool operator==(const SaplingNoteData& a, const SaplingNoteData& b) {
-        return (a.ivk == b.ivk && a.nullifier == b.nullifier && a.witnessHeight == b.witnessHeight);
+        return (a.ivk == b.ivk &&
+                a.nullifier == b.nullifier &&
+                a.witnessHeight == b.witnessHeight &&
+                a.amount == b.amount &&
+                a.address == b.address &&
+                a.memo == b.memo);
     }
 
     friend bool operator!=(const SaplingNoteData& a, const SaplingNoteData& b) {

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -180,6 +180,8 @@ public:
     void SetHDChain(CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
 
+    uint256 getCommonOVK();
+    void setCommonOVK(const uint256& ovk) { commonOVK = ovk; }
     uint256 getCommonOVKFromSeed();
 
     /* Encrypt Sapling keys */
@@ -376,6 +378,8 @@ private:
     CWallet* wallet{nullptr};
     /* the HD chain data model (external/internal chain counters) */
     CHDChain hdChain;
+    /* cached common OVK for sapling spends from t addresses */
+    Optional<uint256> commonOVK;
 
 
     /**

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -180,9 +180,13 @@ public:
     void SetHDChain(CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
 
+    /* Get cached sapling commonOVK
+     * If nullopt, read it from the database, and save it.
+     * If not found in the database, create a new one from the HD seed (throw
+     * if the wallet is locked), write it to database, and save it.
+     */
     uint256 getCommonOVK();
     void setCommonOVK(const uint256& ovk) { commonOVK = ovk; }
-    uint256 getCommonOVKFromSeed();
 
     /* Encrypt Sapling keys */
     bool EncryptSaplingKeys(CKeyingMaterial& vMasterKeyIn);
@@ -380,6 +384,7 @@ private:
     CHDChain hdChain;
     /* cached common OVK for sapling spends from t addresses */
     Optional<uint256> commonOVK;
+    uint256 getCommonOVKFromSeed() const;
 
 
     /**

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -45,8 +45,11 @@ public:
     SaplingNoteData(const libzcash::SaplingIncomingViewingKey& _ivk) : ivk {_ivk}, nullifier() { }
     SaplingNoteData(const libzcash::SaplingIncomingViewingKey& _ivk, const uint256& n) : ivk {_ivk}, nullifier(n) { }
 
+    /* witnesses/ivk: only for own (received) outputs */
     std::list<SaplingWitness> witnesses;
-    libzcash::SaplingIncomingViewingKey ivk;
+    Optional<libzcash::SaplingIncomingViewingKey> ivk {nullopt};
+    inline bool IsMyNote() const { return ivk != nullopt; }
+
     /**
      * Cached note amount.
      * It will be loaded the first time that the note is decrypted.

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -294,11 +294,6 @@ public:
     std::set<std::pair<libzcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzcash::PaymentAddress> & addresses);
     bool IsNoteSaplingChange(const std::set<std::pair<libzcash::PaymentAddress, uint256>>& nullifierSet, const libzcash::PaymentAddress& address, const SaplingOutPoint& entry);
 
-    //! Decrypt the encrypted note and return the address if possible
-    Optional<libzcash::SaplingPaymentAddress> GetShieldedAddressFrom(const CWalletTx& tx, const SaplingOutPoint& op);
-
-    //! Try to decrypt the note and load the amount into the always available SaplingNoteData
-    CAmount TryToRecoverAndSetAmount(const CWalletTx& tx, const SaplingOutPoint& op);
     //! Try to recover the note using the wallet's ovks (mostly used when the outpoint is a debit)
     Optional<std::pair<
             libzcash::SaplingNotePlaintext,
@@ -306,7 +301,9 @@ public:
 
     //! Return true if the wallet can decrypt & spend the shielded output.
     isminetype IsMine(const CWalletTx& wtx, const SaplingOutPoint& op);
-    //! Return the shielded value of an specific output
+    //! Return the shielded address of a specific outpoint of wallet transaction
+    Optional<libzcash::SaplingPaymentAddress> GetOutPointAddress(const CWalletTx& tx, const SaplingOutPoint& op);
+    //! Return the shielded value of a specific outpoint of wallet transaction
     CAmount GetOutPointValue(const CWalletTx& tx, const SaplingOutPoint& op);
     //! Return the shielded credit of the tx
     CAmount GetCredit(const CWalletTx& tx, const isminefilter& filter, const bool fUnspent = false);

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -52,15 +52,21 @@ public:
 
     /**
      * Cached note amount.
-     * It will be loaded the first time that the note is decrypted.
+     * It will be loaded the first time that the note is decrypted (when the tx is added to the wallet).
      */
     Optional<CAmount> amount{nullopt};
 
     /**
      * Cached shielded address
-     * It will be loaded the first time that the note is decrypted
+     * It will be loaded the first time that the note is decrypted (when the tx is added to the wallet)
      */
      Optional<libzcash::SaplingPaymentAddress> address{nullopt};
+
+     /**
+      * Cached note memo (only for non-empty memo)
+      * It will be loaded the first time that the note is decrypted (when the tx is added to the wallet)
+      */
+     Optional<std::array<unsigned char, ZC_MEMO_SIZE>> memo;
 
     /**
      * Block height corresponding to the most current witness.

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldedsendmany_taddr_to_sapling)
 
     BOOST_CHECK(libzcash::AttemptSaplingOutDecryption(
             tx.sapData->vShieldedOutput[0].outCiphertext,
-            pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVKFromSeed(),
+            pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVK(),
             tx.sapData->vShieldedOutput[0].cv,
             tx.sapData->vShieldedOutput[0].cmu,
             tx.sapData->vShieldedOutput[0].ephemeralKey));

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -117,7 +117,8 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
     BOOST_CHECK(noteData == wtx.mapSaplingNoteData);
 
     // Test individual fields in case equality operator is defined/changed.
-    BOOST_CHECK(ivk == wtx.mapSaplingNoteData[op].ivk);
+    BOOST_CHECK(wtx.mapSaplingNoteData[op].IsMyNote());
+    BOOST_CHECK(ivk == *(wtx.mapSaplingNoteData[op].ivk));
     BOOST_CHECK(nullifier == wtx.mapSaplingNoteData[op].nullifier);
     BOOST_CHECK(nd.witnessHeight == wtx.mapSaplingNoteData[op].witnessHeight);
     BOOST_CHECK(witness == wtx.mapSaplingNoteData[op].witnesses.front());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1360,8 +1360,10 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
 
     // Collect OutgoingViewingKeys for recovering output information
     std::set<uint256> ovks;
-    // Generate the common ovk for recovering t->shield outputs.
-    ovks.insert(sspkm->getCommonOVKFromSeed());
+    // Get the common OVK for recovering t->shield outputs.
+    // If not already databased, a new one will be generated from the HD seed.
+    // It is safe to do it here, as the wallet is unlocked.
+    ovks.insert(sspkm->getCommonOVK());
 
     // Sapling spends
     for (size_t i = 0; i < wtx.sapData->vShieldedSpend.size(); ++i) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1051,7 +1051,11 @@ void CWallet::AddExternalNotesDataToTx(CWalletTx& wtx) const
                 // Always true for 'IsFromMe' transactions
                 wtx.mapSaplingNoteData[op].address = recovered->second;
                 wtx.mapSaplingNoteData[op].amount = recovered->first.value();
-                wtx.mapSaplingNoteData[op].memo = recovered->first.memo();
+                const auto& memo = recovered->first.memo();
+                // don't save empty memo (starting with 0xF6)
+                if (memo[0] < 0xF6) {
+                    wtx.mapSaplingNoteData[op].memo = memo;
+                }
             }
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1051,6 +1051,7 @@ void CWallet::AddExternalNotesDataToTx(CWalletTx& wtx) const
                 // Always true for 'IsFromMe' transactions
                 wtx.mapSaplingNoteData[op].address = recovered->second;
                 wtx.mapSaplingNoteData[op].amount = recovered->first.value();
+                wtx.mapSaplingNoteData[op].memo = recovered->first.memo();
             }
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -518,6 +518,8 @@ public:
 
     // Search for notes and addresses from this wallet in the tx, and add the addresses --> IVK mapping to the keystore if missing.
     bool FindNotesDataAndAddMissingIVKToKeystore(const CTransaction& tx, Optional<mapSaplingNoteData_t>& saplingNoteData);
+    // Decrypt sapling output notes with the inputs ovk and updates saplingNoteDataMap
+    void AddExternalNotesDataToTx(CWalletTx& wtx) const;
 
     //! Generates new Sapling key
     libzcash::SaplingPaymentAddress GenerateNewSaplingZKey(std::string label = "");

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -149,6 +149,17 @@ bool CWalletDB::WriteCryptedSaplingZKey(
     return true;
 }
 
+bool CWalletDB::WriteSaplingCommonOVK(const uint256& ovk)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::string("commonovk"), ovk);
+}
+
+bool CWalletDB::ReadSaplingCommonOVK(uint256& ovkRet)
+{
+    return Read(std::string("commonovk"), ovkRet);
+}
+
 bool CWalletDB::WriteWitnessCacheSize(int64_t nWitnessCacheSize)
 {
     nWalletDBUpdateCounter++;
@@ -650,14 +661,16 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssKey >> ivk;
             libzcash::SaplingExtendedSpendingKey key;
             ssValue >> key;
-
             if (!pwallet->LoadSaplingZKey(key)) {
                 strErr = "Error reading wallet database: LoadSaplingZKey failed";
                 return false;
             }
-
             //add checks for integrity
             wss.nZKeys++;
+        } else if (strType == "commonovk") {
+            uint256 ovk;
+            ssValue >> ovk;
+            // !TODO: cache ovk value in the wallet
         } else if (strType == "csapzkey") {
             libzcash::SaplingIncomingViewingKey ivk;
             ssKey >> ivk;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -670,7 +670,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
         } else if (strType == "commonovk") {
             uint256 ovk;
             ssValue >> ovk;
-            // !TODO: cache ovk value in the wallet
+            pwallet->GetSaplingScriptPubKeyMan()->setCommonOVK(ovk);
         } else if (strType == "csapzkey") {
             libzcash::SaplingIncomingViewingKey ivk;
             ssKey >> ivk;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -164,6 +164,10 @@ public:
                                  const std::vector<unsigned char>& vchCryptedSecret,
                                  const CKeyMetadata &keyMeta);
 
+    /// Common output viewing key, used when shielding transparent funds
+    bool WriteSaplingCommonOVK(const uint256& ovk);
+    bool ReadSaplingCommonOVK(uint256& ovkRet);
+
     bool WriteWitnessCacheSize(int64_t nWitnessCacheSize);
 
     /// Write destination data key,value tuple to database


### PR DESCRIPTION
Several updates and fixes around the decrypted data cached in `mapSaplingNoteData` for wallet transactions for https://github.com/PIVX-Project/PIVX/pull/1963

- save the common OVK used to recover t-->shield spends, database it, and update it when updating the HD seed (fixing the current crashes, due to calls to `getCommonOVKFromSeed` with a locked wallet, and inability to show in the GUI transactions with external shielded address).
- fix a bug with the selection of the proper ovk for shielded inputs (`extfvk.fvk.ovk` instead of `extsk.expsk.ovk`).
- try to recover a note with all shielded inputs ovk in `TryToRecoverNote` (but not when sending from transparent, as we have no mixed input types).
- for `IsMine` transaction cache the data of **all** outputs, even "external" ones. This drastically changes and refactors the flow, due to the assumption that mapSaplingNoteData is populated only for "own" notes, that is no longer true. 
Make the note ivk an optional, and add a `IsMyNote` function that returns true if the ivk is set.
- Decrypt the notes and update the map, only when adding a transaction to the wallet, and rely on the cached data everywhere else.
- Add the memo to mapSaplingNoteData to be easily accessible from the GUI, without requiring another decryption.
- Remove all unneeded decrypt operations.
- Database the new cached data of the map (by adding it to the serialization).